### PR TITLE
Fixes for Ubuntu 22.10

### DIFF
--- a/instfiles/load_pw_modules.sh
+++ b/instfiles/load_pw_modules.sh
@@ -62,8 +62,10 @@ if [ -n "$XRDP_SESSION" -a -n "$XRDP_SOCKET_PATH" ]; then
     # set default sample rate = 44100, because xrdp uses it.
     pw-metadata -n settings 0 default.clock.rate 44100 >/dev/null
 
-    pactl set-default-sink xrdp-sink
-    pactl set-default-source xrdp-source
+    if command -v pactl >/dev/null; then
+        pactl set-default-sink xrdp-sink
+        pactl set-default-source xrdp-source
+    fi
 fi
 
 exit $status

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,14 +2,14 @@ AM_CFLAGS =
 AM_LDFLAGS =
 
 if USE_ALT_PW_CLI
-pkglibexec_PROGRAMS = cli_0358_mod
+pkglibexec_PROGRAMS = pw-cli_0358_mod
 endif
 
 modlibexec_LTLIBRARIES = libpipewire-module-xrdp-pipewire.la
 
-cli_0358_mod_SOURCES = pw-cli_0358_mod.c
-cli_0358_mod_CFLAGS =  $(PW_CFLAGS) $(SPA_CFLAGS)
-cli_0358_mod_LDFLAGS = $(PW_LIBS)
+pw_cli_0358_mod_SOURCES = pw-cli_0358_mod.c
+pw_cli_0358_mod_CFLAGS =  $(PW_CFLAGS) $(SPA_CFLAGS)
+pw_cli_0358_mod_LDFLAGS = $(PW_LIBS)
 
 libpipewire_module_xrdp_pipewire_la_SOURCES = module-xrdp-pipewire.c
 libpipewire_module_xrdp_pipewire_la_CFLAGS = $(PW_CFLAGS) $(SPA_CFLAGS) -fPIC


### PR DESCRIPTION
The name of the CLI executable is wring on the Makefile, and pactl does not need to be installed. If it isn't the compatibility commands can be skipped.