### PR TITLE
Increase compiler warning level

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,10 @@ fi
 
 AM_CONDITIONAL(USE_ALT_PW_CLI, [test "x$alt_pw_cli" = xyes])
 
+# configure compiler options and CFLAGS
+AX_CFLAGS_WARN_ALL
+AX_APPEND_COMPILE_FLAGS([-Wwrite-strings])
+
 AC_CONFIG_FILES([Makefile
                  src/Makefile
                  instfiles/Makefile])

--- a/m4/ax_append_compile_flags.m4
+++ b/m4/ax_append_compile_flags.m4
@@ -1,0 +1,46 @@
+# ============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_append_compile_flags.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_COMPILE_FLAGS([FLAG1 FLAG2 ...], [FLAGS-VARIABLE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   For every FLAG1, FLAG2 it is checked whether the compiler works with the
+#   flag.  If it does, the flag is added FLAGS-VARIABLE
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  During the check the flag is always added to the
+#   current language's flags.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: This macro depends on the AX_APPEND_FLAG and
+#   AX_CHECK_COMPILE_FLAG. Please keep this macro in sync with
+#   AX_APPEND_LINK_FLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AC_DEFUN([AX_APPEND_COMPILE_FLAGS],
+[AX_REQUIRE_DEFINED([AX_CHECK_COMPILE_FLAG])
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+for flag in $1; do
+  AX_CHECK_COMPILE_FLAG([$flag], [AX_APPEND_FLAG([$flag], [$2])], [], [$3], [$4])
+done
+])dnl AX_APPEND_COMPILE_FLAGS

--- a/m4/ax_append_flag.m4
+++ b/m4/ax_append_flag.m4
@@ -1,0 +1,50 @@
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 8
+
+AC_DEFUN([AX_APPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_APPEND(FLAGS,[" $1"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/m4/ax_cflags_warn_all.m4
+++ b/m4/ax_cflags_warn_all.m4
@@ -1,0 +1,158 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_cflags_warn_all.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CFLAGS_WARN_ALL   [(shellvar[, default[, action-if-found[, action-if-not-found]]])]
+#   AX_CXXFLAGS_WARN_ALL [(shellvar[, default[, action-if-found[, action-if-not-found]]])]
+#   AX_FCFLAGS_WARN_ALL  [(shellvar[, default[, action-if-found[, action-if-not-found]]])]
+#
+# DESCRIPTION
+#
+#   Specify compiler options that enable most reasonable warnings.  For the
+#   GNU Compiler Collection (GCC), for example, it will be "-Wall".  The
+#   result is added to shellvar, one of CFLAGS, CXXFLAGS or FCFLAGS if the
+#   first parameter is not specified.
+#
+#   Each of these macros accepts the following optional arguments:
+#
+#     - $1 - shellvar
+#         shell variable to use (CFLAGS, CXXFLAGS or FCFLAGS if not
+#         specified, depending on macro)
+#
+#     - $2 - default
+#         value to use for flags if compiler vendor cannot be determined (by
+#         default, "")
+#
+#     - $3 - action-if-found
+#         action to take if the compiler vendor has been successfully
+#         determined (by default, add the appropriate compiler flags to
+#         shellvar)
+#
+#     - $4 - action-if-not-found
+#         action to take if the compiler vendor has not been determined or
+#         is unknown (by default, add the default flags, or "" if not
+#         specified, to shellvar)
+#
+#   These macros use AX_COMPILER_VENDOR to determine which flags should be
+#   returned for a given compiler.  Not all compilers currently have flags
+#   defined for them; patches are welcome.  If need be, compiler flags may
+#   be made language-dependent: use a construct like the following:
+#
+#     [vendor_name], [m4_if(_AC_LANG_PREFIX,[C],   VAR="--relevant-c-flags",dnl
+#                     m4_if(_AC_LANG_PREFIX,[CXX], VAR="--relevant-c++-flags",dnl
+#                     m4_if(_AC_LANG_PREFIX,[FC],  VAR="--relevant-fortran-flags",dnl
+#                     VAR="$2"; FOUND="no")))],
+#
+#   Note: These macros also depend on AX_PREPEND_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2010 Rhys Ulerich <rhys.ulerich@gmail.com>
+#   Copyright (c) 2018 John Zaitseff <J.Zaitseff@zap.org.au>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 25
+
+AC_DEFUN([AX_FLAGS_WARN_ALL], [
+    AX_REQUIRE_DEFINED([AX_PREPEND_FLAG])dnl
+    AC_REQUIRE([AX_COMPILER_VENDOR])dnl
+
+    AS_VAR_PUSHDEF([FLAGS], [m4_default($1,_AC_LANG_PREFIX[]FLAGS)])dnl
+    AS_VAR_PUSHDEF([VAR],   [ac_cv_[]_AC_LANG_ABBREV[]flags_warn_all])dnl
+    AS_VAR_PUSHDEF([FOUND], [ac_save_[]_AC_LANG_ABBREV[]flags_warn_all_found])dnl
+
+    AC_CACHE_CHECK([FLAGS for most reasonable warnings], VAR, [
+	VAR=""
+	FOUND="yes"
+	dnl  Cases are listed in the order found in ax_compiler_vendor.m4
+	AS_CASE("$ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor",
+	    [intel],		[VAR="-w2"],
+	    [ibm],		[VAR="-qsrcmsg -qinfo=all:noppt:noppc:noobs:nocnd"],
+	    [pathscale],	[],
+	    [clang],		[VAR="-Wall"],
+	    [cray],		[VAR="-h msglevel 2"],
+	    [fujitsu],		[],
+	    [sdcc],		[],
+	    [sx],		[VAR="-pvctl[,]fullmsg"],
+	    [portland],		[],
+	    [gnu],		[VAR="-Wall"],
+	    [sun],		[VAR="-v"],
+	    [hp],		[VAR="+w1"],
+	    [dec],		[VAR="-verbose -w0 -warnprotos"],
+	    [borland],		[],
+	    [comeau],		[],
+	    [kai],		[],
+	    [lcc],		[],
+	    [sgi],		[VAR="-fullwarn"],
+	    [microsoft],	[],
+	    [metrowerks],	[],
+	    [watcom],		[],
+	    [tcc],		[],
+	    [unknown],		[
+				    VAR="$2"
+				    FOUND="no"
+				],
+				[
+				    AC_MSG_WARN([Unknown compiler vendor returned by [AX_COMPILER_VENDOR]])
+				    VAR="$2"
+				    FOUND="no"
+				]
+	)
+
+	AS_IF([test "x$FOUND" = "xyes"], [dnl
+	    m4_default($3, [AS_IF([test "x$VAR" != "x"], [AX_PREPEND_FLAG([$VAR], [FLAGS])])])
+	], [dnl
+	    m4_default($4, [m4_ifval($2, [AX_PREPEND_FLAG([$VAR], [FLAGS])], [true])])
+	])dnl
+    ])dnl
+
+    AS_VAR_POPDEF([FOUND])dnl
+    AS_VAR_POPDEF([VAR])dnl
+    AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_FLAGS_WARN_ALL
+
+AC_DEFUN([AX_CFLAGS_WARN_ALL], [dnl
+    AC_LANG_PUSH([C])
+    AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+    AC_LANG_POP([C])
+])dnl
+
+AC_DEFUN([AX_CXXFLAGS_WARN_ALL], [dnl
+    AC_LANG_PUSH([C++])
+    AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+    AC_LANG_POP([C++])
+])dnl
+
+AC_DEFUN([AX_FCFLAGS_WARN_ALL], [dnl
+    AC_LANG_PUSH([Fortran])
+    AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+    AC_LANG_POP([Fortran])
+])dnl

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/m4/ax_compiler_vendor.m4
+++ b/m4/ax_compiler_vendor.m4
@@ -1,0 +1,119 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compiler_vendor.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_VENDOR
+#
+# DESCRIPTION
+#
+#   Determine the vendor of the C, C++ or Fortran compiler.  The vendor is
+#   returned in the cache variable $ax_cv_c_compiler_vendor for C,
+#   $ax_cv_cxx_compiler_vendor for C++ or $ax_cv_fc_compiler_vendor for
+#   (modern) Fortran.  The value is one of "intel", "ibm", "pathscale",
+#   "clang" (LLVM), "cray", "fujitsu", "sdcc", "sx", "nvhpc" (NVIDIA HPC
+#   Compiler), "portland" (PGI), "gnu" (GCC), "sun" (Oracle Developer
+#   Studio), "hp", "dec", "borland", "comeau", "kai", "lcc", "sgi",
+#   "microsoft", "metrowerks", "watcom", "tcc" (Tiny CC) or "unknown" (if
+#   the compiler cannot be determined).
+#
+#   To check for a Fortran compiler, you must first call AC_FC_PP_SRCEXT
+#   with an appropriate preprocessor-enabled extension.  For example:
+#
+#     AC_LANG_PUSH([Fortran])
+#     AC_PROG_FC
+#     AC_FC_PP_SRCEXT([F])
+#     AX_COMPILER_VENDOR
+#     AC_LANG_POP([Fortran])
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2008 Matteo Frigo
+#   Copyright (c) 2018-19 John Zaitseff <J.Zaitseff@zap.org.au>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 32
+
+AC_DEFUN([AX_COMPILER_VENDOR], [dnl
+    AC_CACHE_CHECK([for _AC_LANG compiler vendor], ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor, [dnl
+	dnl  If you modify this list of vendors, please add similar support
+	dnl  to ax_compiler_version.m4 if at all possible.
+	dnl
+	dnl  Note: Do NOT check for GCC first since some other compilers
+	dnl  define __GNUC__ to remain compatible with it.  Compilers that
+	dnl  are very slow to start (such as Intel) are listed first.
+
+	vendors="
+		intel:		__ICC,__ECC,__INTEL_COMPILER
+		ibm:		__xlc__,__xlC__,__IBMC__,__IBMCPP__,__ibmxl__
+		pathscale:	__PATHCC__,__PATHSCALE__
+		clang:		__clang__
+		cray:		_CRAYC
+		fujitsu:	__FUJITSU
+		sdcc:		SDCC,__SDCC
+		sx:		_SX
+		nvhpc:		__NVCOMPILER
+		portland:	__PGI
+		gnu:		__GNUC__
+		sun:		__SUNPRO_C,__SUNPRO_CC,__SUNPRO_F90,__SUNPRO_F95
+		hp:		__HP_cc,__HP_aCC
+		dec:		__DECC,__DECCXX,__DECC_VER,__DECCXX_VER
+		borland:	__BORLANDC__,__CODEGEARC__,__TURBOC__
+		comeau:		__COMO__
+		kai:		__KCC
+		lcc:		__LCC__
+		sgi:		__sgi,sgi
+		microsoft:	_MSC_VER
+		metrowerks:	__MWERKS__
+		watcom:		__WATCOMC__
+		tcc:		__TINYC__
+		unknown:	UNKNOWN
+	"
+	for ventest in $vendors; do
+	    case $ventest in
+		*:)
+		    vendor=$ventest
+		    continue
+		    ;;
+		*)
+		    vencpp="defined("`echo $ventest | sed 's/,/) || defined(/g'`")"
+		    ;;
+	    esac
+
+	    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+#if !($vencpp)
+      thisisanerror;
+#endif
+	    ]])], [break])
+	done
+
+	ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor=`echo $vendor | cut -d: -f1`
+    ])
+])dnl

--- a/m4/ax_prepend_flag.m4
+++ b/m4/ax_prepend_flag.m4
@@ -1,0 +1,51 @@
+# ===========================================================================
+#     https://www.gnu.org/software/autoconf-archive/ax_prepend_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PREPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is added to the front of the FLAGS-VARIABLE shell variable, with a
+#   space added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_APPEND_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#   Copyright (c) 2018 John Zaitseff <J.Zaitseff@zap.org.au>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_PREPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     FLAGS="$1 $FLAGS"
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_PREPEND_FLAG

--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,8 +7,9 @@ endif
 
 modlibexec_LTLIBRARIES = libpipewire-module-xrdp-pipewire.la
 
+# _GNU_SOURCE needed for asprintf() declaration
 pw_cli_0358_mod_SOURCES = pw-cli_0358_mod.c
-pw_cli_0358_mod_CFLAGS =  $(PW_CFLAGS) $(SPA_CFLAGS)
+pw_cli_0358_mod_CFLAGS =  $(PW_CFLAGS) $(SPA_CFLAGS) -D_GNU_SOURCE
 pw_cli_0358_mod_LDFLAGS = $(PW_LIBS)
 
 libpipewire_module_xrdp_pipewire_la_SOURCES = module-xrdp-pipewire.c

--- a/src/module-xrdp-pipewire.c
+++ b/src/module-xrdp-pipewire.c
@@ -368,7 +368,6 @@ static void set_socket_path(struct impl *impl) {
 
     const char *socket_dir;
     const char *socket_name;
-    char default_socket_name[64];
 
     socket_dir = getenv("XRDP_SOCKET_PATH");
     if (socket_dir == NULL || socket_dir[0] == '\0') {
@@ -999,8 +998,10 @@ int pipewire__module_init(struct pw_impl_module *module, const char *args)
 		goto error;
 	}
 
-	if (!impl->mode)
+	if (!impl->mode) {
+		res = -EINVAL;
 		goto error;
+	}
 
 	impl->core = pw_context_get_object(impl->context, PW_TYPE_INTERFACE_Core);
 	if (impl->core == NULL) {

--- a/src/pw-cli_0358_mod.c
+++ b/src/pw-cli_0358_mod.c
@@ -2125,6 +2125,7 @@ static bool parse(struct data *data, char *buf, char **error)
 	int n;
 	size_t i;
 	char *p, *cmd, *args;
+	char empty_arg[] = "";
 
 	if ((p = strchr(buf, '#')))
 		*p = '\0';
@@ -2139,7 +2140,7 @@ static bool parse(struct data *data, char *buf, char **error)
 		return true;
 
 	cmd = a[0];
-	args = n > 1 ? a[1] : "";
+	args = n > 1 ? a[1] : empty_arg;
 
 	for (i = 0; i < SPA_N_ELEMENTS(command_list); i++) {
 		if (spa_streq(command_list[i].name, cmd) ||
@@ -2265,6 +2266,7 @@ static void do_quit_on_signal(void *data, int signal_number)
 
 static void show_help(struct data *data, const char *name, bool error)
 {
+	char empty_arg[] = "";
 	fprintf(error ? stderr : stdout, _("%s [options] [command]\n"
 		"  -h, --help                            Show this help\n"
 		"      --version                         Show version\n"
@@ -2272,7 +2274,7 @@ static void show_help(struct data *data, const char *name, bool error)
 		"  -r, --remote                          Remote daemon name\n\n"),
 		name);
 
-	do_help(data, "help", "", NULL);
+	do_help(data, "help", empty_arg, NULL);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Increase the compiler warning level to catch coding issues.

First commit adds the xrdp defaults `-Wall` and `-Wwrite-strings` to the compiler line.

That results in the following warnings on gcc 12.2.0 (Ubuntu 22.10), fixed in commit 2. Note that module-xrdp-pipewire.c:1041 is an actual error.

```
pw-cli_0358_mod.c: In function ‘parse’:
pw-cli_0358_mod.c:2142:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 2142 |         args = n > 1 ? a[1] : "";
      |              ^
pw-cli_0358_mod.c: In function ‘show_help’:
pw-cli_0358_mod.c:2275:31: warning: passing argument 3 of ‘do_help’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 2275 |         do_help(data, "help", "", NULL);
      |                               ^~
pw-cli_0358_mod.c:276:63: note: expected ‘char *’ but argument is of type ‘const char *’
  276 | static bool do_help(struct data *data, const char *cmd, char *args, char **error)
      |                                                         ~~~~~~^~~~
module-xrdp-pipewire.c: In function 'set_socket_path':
module-xrdp-pipewire.c:371:10: warning: unused variable 'default_socket_name' [-Wunused-variable]
  371 |     char default_socket_name[64];
      |          ^~~~~~~~~~~~~~~~~~~
module-xrdp-pipewire.c: In function 'pipewire__module_init':
module-xrdp-pipewire.c:1041:16: warning: 'res' may be used uninitialized [-Wmaybe-uninitialized]
 1041 |         return res;
      |                ^~~
module-xrdp-pipewire.c:864:13: note: 'res' was declared here
  864 |         int res;
      |             ^~~
```

and also warnings about `asprintf()` not being defined by clang 15.0.7, fixed in commit 3

The module itself also compiles cleanly in Fedora 38 (gcc 13.1.1-2 and clang 16.0.4-1)